### PR TITLE
Change Dependabot Frequency and PR type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      python-packages: # Submits all the Python packages as a single PR (Security Updates are Still Separated)
+        patterns:
+          - "*"


### PR DESCRIPTION
This small PR changes the updated interval to monthly (previously weekly) and combines all the python version updates into a single PR, instead of a single PR per package.

### Dependabot can be noisy

This change makes it easier to maintain.


### What's left

- Add tests to ensure that Dependabot PRs are safe to merge.
- You could make the updates more fine-grained to update portions of the code at different intervals (maybe some AI tooling should be updated more frequently)
